### PR TITLE
Add config option for specifying social links

### DIFF
--- a/acmwebsite/lib/helpers.py
+++ b/acmwebsite/lib/helpers.py
@@ -29,6 +29,10 @@ def icon(icon_name):
     return Markup('<i class="glyphicon glyphicon-%s"></i>' % icon_name)
 
 
+def fa_icon(icon_name):
+    return Markup('<i class="fa fa-{}"></i>'.format(icon_name))
+
+
 def ftime(datetime_obj, duration=None, show_day=False):
     day_fmt = '{0:%A}, ' if show_day else ''
     date_fmt = '{0.day} {0:%B %Y}'

--- a/acmwebsite/public/css/style.css
+++ b/acmwebsite/public/css/style.css
@@ -113,3 +113,14 @@
 .acm-meeting-title {
   font-weight: bold;
 }
+
+/* Footer */
+footer .social-links {
+  margin-top: 10px;
+  text-align: center;
+  font-size: 2em;
+}
+
+footer .social-links a:not(:last-child) {
+  margin-right: 10px;
+}

--- a/acmwebsite/templates/master.xhtml
+++ b/acmwebsite/templates/master.xhtml
@@ -12,7 +12,7 @@
   </head>
 
   <body>
-    <!-- Navbar -->
+    <!--! Navbar -->
     <div class="container">
       <div class="header-logo">
         <a href="${tg.url('/')}">
@@ -61,7 +61,7 @@
     </div>
     <div class="container site-content">
 
-      <!-- Flash messages -->
+      <!--! Flash messages -->
       <py:with vars="flash=tg.flash_obj.render('flash', use_js=False)">
       <div class="row">
         <div class="col-md-8 col-md-offset-2">
@@ -70,7 +70,7 @@
         </div>
       </py:with>
 
-      <!-- Main included content -->
+      <!--! Main included content -->
       <py:block name="body"/>
       </div>
       <div class="container site-footer">
@@ -78,10 +78,21 @@
         <footer class="footer">
           <p>
           <small>
-            Unless otherwise noted, all content on this website is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/">Creative Commons Attribution-ShareAlike 4.0 International License</a>.
+            Unless otherwise noted, all content on this website is licensed under a
+            <a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/">
+              Creative Commons Attribution-ShareAlike 4.0 International License
+            </a>.
           </small>
           </p>
           <p><small><a href='#' id='toggle-theme'>Too ${('light', 'dark')[tg.session.get('theme', None) == 'dark']}?</a></small></p>
+
+          <!--! Social Links -->
+          <p class="social-links" py:if="tg.config.get('social_links')">
+            <a py:for="link in tg.config.get('social_links').split(',')"
+              py:content="h.fa_icon(link)"
+              href="${tg.config.get('social_links.{}'.format(link))}">
+            </a>
+          </p>
         </footer>
       </div>
 

--- a/development.ini.sample
+++ b/development.ini.sample
@@ -60,6 +60,11 @@ mailman.url = https://mailman.mines.edu/mailman/admin/acmx
 mailman.pipermail.url = https://mailman.mines.edu/pipermail/acmx
 mailman.secret = getthisfromjack
 
+# Social Links
+social_links = github,facebook
+social_links.github = https://github.com/ColoradoSchoolOfMines
+social_links.facebook = https://facebook.com/minesacm
+
 #By default session is store in cookies to avoid the overhead
 #of having to manage a session storage. On production you might
 #want to switch to a better session storage.


### PR DESCRIPTION
Resolves #16.

## Features
- The sys admin can specify a list of social links to display in the footer using the `.ini` config file.

## Notes
- I wasn't sure how to make a dictionary in the `.ini` file. Any suggestions would be appreciated.
- The `helpers.fa_icon` function is also in #35. I didn't want to merge branches, so it's duplicated here.